### PR TITLE
Handle the new CLA signatories.

### DIFF
--- a/.sticker.yml
+++ b/.sticker.yml
@@ -1,4 +1,0 @@
----
-linters:
-    pep8:
-        python: 3

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,2 +1,4 @@
+---
 linters:
-  flake8: {  }
+    pep8:
+        python: 3

--- a/scitools_cla_checker/update_pr.py
+++ b/scitools_cla_checker/update_pr.py
@@ -198,7 +198,15 @@ def get_contributors():
     content = json.loads(response.body.decode())
     signatures = sorted([person['profile_name']
                          for person in content['contributors']])
-    return signatures
+
+    v4_json = (
+            'https://script.google.com/macros/s/'
+            'AKfycbwqZ0JLlOKJEcvYUYFXo77o6nux9tSHvOJISUnk3yHi-Bk0Qanz/exec')
+    response = yield http_client.fetch(v4_json)
+    content = json.loads(response.body.decode())
+    v4_signatures = sorted(content['signatories'])
+
+    return sorted(signatures + v4_signatures)
 
 
 def configure_default_client():


### PR DESCRIPTION
There is a new service which we can query to get the list of those who have signed the v4 CLA.

For now we blend the two sources together, but will want to rapidly move towards removing the old location at https://github.com/SciTools/scitools.org.uk/blob/master/contributors.json.

It remains for me to document this properly in https://github.com/SciTools/scitools.org.uk/pull/209.